### PR TITLE
Fixed problematic generate_key.sh line in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,7 +33,7 @@ COPY config/mwaa-base-providers-requirements.txt /mwaa-base-providers-requiremen
 
 RUN chmod u+x /systemlibs.sh && /systemlibs.sh
 RUN chmod u+x /bootstrap.sh && /bootstrap.sh
-RUN chmod u+x /generate_key.sh && /generate_key.sh
+RUN bash /generate_key.sh
 RUN chmod u+x /run-startup.sh
 RUN chmod u+x /shell-launch-script.sh
 RUN chmod u+x /verification.sh


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When running any `rearc airflow` command, the line `RUN chmod u+x /generate_key.sh && /generate_key.sh` in the dockerfile failed with:

```
 => CACHED [ 9/20] COPY config/mwaa-base-providers-requirements.txt /mwaa-base-providers-requirements.txt          0.0s
 => CACHED [10/20] RUN chmod u+x /systemlibs.sh && /systemlibs.sh                                                  0.0s
 => CACHED [11/20] RUN chmod u+x /bootstrap.sh && /bootstrap.sh                                                    0.0s
 => ERROR [12/20] RUN chmod u+x /generate_key.sh && /generate_key.sh                                               0.1s
------
 > [12/20] RUN chmod u+x /generate_key.sh && /generate_key.sh:
: No such file or directory
------
failed to solve: process "/bin/sh -c chmod u+x /generate_key.sh && /generate_key.sh" did not complete successfully: exit code: 127
[17:50:57] ERROR    Command failed                                                                       command.py:215
```

This changes the problematic line to `RUN bash /generate_key.sh` instead, which succeeds.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
